### PR TITLE
all mentions of 2021 changed to 2022

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Richard Moore
+Copyright (c) 2022 Richard Moore
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/landing/building.html
+++ b/landing/building.html
@@ -80,7 +80,7 @@
       </div>
     </div>
     <div class="separator"></div>
-    <div class="copyright">Copyright &copy;2021 <a class="link" href="mailto:me@ricmoo.com">Richard Moore</a>. Some rights reserved.</div>
+    <div class="copyright">Copyright &copy;2022 <a class="link" href="mailto:me@ricmoo.com">Richard Moore</a>. Some rights reserved.</div>
   </body>
 </html>
       

--- a/landing/index.html
+++ b/landing/index.html
@@ -90,7 +90,7 @@
         <div class="separator"></div>
       </div>
     </div>
-    <div class="copyright">Copyright &copy;2021 <a class="link" href="mailto:me@ricmoo.com">Richard Moore</a>. Some rights reserved.</div>
+    <div class="copyright">Copyright &copy;2022 <a class="link" href="mailto:me@ricmoo.com">Richard Moore</a>. Some rights reserved.</div>
 
     <div id="templates" style="display: none">
       <a id="template-backer" data-href="https://ethereum.org" rel="noreferrer noopener" target="_blank"><div class="backer"></div><div class="title"></div></a>

--- a/landing/sponsoring.html
+++ b/landing/sponsoring.html
@@ -145,7 +145,7 @@
       </div>
     </div>
     <div class="separator"></div>
-    <div class="copyright">Copyright &copy;2021 <a class="link" href="mailto:me@ricmoo.com">Richard Moore</a>. Some rights reserved.</div>
+    <div class="copyright">Copyright &copy;2022 <a class="link" href="mailto:me@ricmoo.com">Richard Moore</a>. Some rights reserved.</div>
   </body>
 </html>
       


### PR DESCRIPTION
Says 2021 at base of most pages, and on the MIT license. Updated to 2022